### PR TITLE
Rename `ui-plugin-find-packages-titles` to `ui-plugin-find-package-title`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## [1.0.0] (https://github.com/folio-org/ui-plugin-find-packages-titles/tree/v1.0.0) (2020-06-12)
+## [1.0.0] (https://github.com/folio-org/ui-plugin-find-package-title/tree/v1.0.0) (2020-06-12)
 
 * New plugin created

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ui-plugin-find-packages-titles
+# ui-plugin-find-package-title
 
 Copyright (C) 2017-2018 The Open Library Foundation
 


### PR DESCRIPTION
## Purpose
- Rename the plugin to comply with Folio plugin naming pattern