### PR TITLE
Refactor to MirageJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [1.1.0] (IN PROGRESS)
 
 * Added ability to select multiple packages. Refs UIPFPAT-4.
+* Replace `bigtest/mirage` with `miragejs`.
 
 ## [1.0.1] (https://github.com/folio-org/ui-plugin-find-package-title/tree/v1.0.1) (2020-06-15)
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "node": ">=6.0.0"
   },
   "stripes": {
-    "actsAs": ["plugin"],
+    "actsAs": [
+      "plugin"
+    ],
     "pluginType": "find-package-title",
     "displayName": "ui-plugin-find-package-title.meta.title",
     "queryResource": "query",
@@ -31,7 +33,6 @@
   },
   "devDependencies": {
     "@bigtest/interactor": "^0.9.1",
-    "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.0",
@@ -42,6 +43,8 @@
     "chai": "^4.2.0",
     "core-js": "^3.6.4",
     "eslint": "^5.5.0",
+    "inflected": "^2.0.4",
+    "miragejs": "^0.1.40",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-intl": "^4.5.3",
@@ -50,15 +53,15 @@
     "sinon": "^7.3.2"
   },
   "dependencies": {
-    "prop-types": "^15.6.0",
     "classnames": "^2.2.5",
-    "react-final-form": "^6.3.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "prop-types": "^15.6.0",
+    "react-final-form": "^6.3.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^4.0.0",
     "react": "*",
-    "react-router-dom": "^4.0.0",
-    "react-intl": "^4.5.3"
+    "react-intl": "^4.5.3",
+    "react-router-dom": "^4.0.0"
   }
 }

--- a/test/bigtest/helpers/helpers.js
+++ b/test/bigtest/helpers/helpers.js
@@ -12,7 +12,10 @@ export default function setupApplication({
   hasAllPerms = true,
 } = {}) {
   setupStripesCore({
-    mirageOptions,
+    mirageOptions: {
+      serverType: 'miragejs',
+      ...mirageOptions
+    },
     scenarios,
     stripesConfig: { hasAllPerms },
 

--- a/test/bigtest/network/index.js
+++ b/test/bigtest/network/index.js
@@ -1,4 +1,4 @@
-import { camelize } from '@bigtest/mirage';
+import { camelize, underscore } from 'inflected';
 
 // auto-import all mirage submodules
 const req = require.context('./', true, /\.js$/);
@@ -8,7 +8,7 @@ const modules = req.keys().reduce((acc, modulePath) => {
   const moduleName = moduleParts[2];
 
   if (moduleName) {
-    const moduleKey = camelize(moduleName.replace('.js', ''));
+    const moduleKey = camelize(underscore(moduleName.replace('.js', '')), false);
 
     return Object.assign(acc, {
       [moduleType]: {


### PR DESCRIPTION
## Motivation
![Screen Shot 2020-07-14 at 4 57 15 PM](https://user-images.githubusercontent.com/29791650/87475647-25324e00-c5f3-11ea-91b6-6d53fdfacdf4.png)
This is part of an on-going initiative to completely migrate all of `folio-org` projects from `@bigtest/mirage` to `miragejs`.

[`@bigtest/mirage`](https://github.com/bigtestjs/mirage/) was originally a prototype to make `mirage` available to any framework, but it has since been archived in favor of [`miragejs`](https://miragejs.com/). The documentation for `miragejs` is not only prodigious for its extensive API docs but also for its tutorials and guides. Furthermore, it receives regular bug-fixes and maintenance releases in thanks to its extremely large and active community.

Previous PR: [@folio-org/ui-plugin-find-eresource #10](https://github.com/folio-org/ui-plugin-find-eresource/pull/10)
_Linking the previous pull request so that subsequent ones can be found tagged below._

<details>
<summary>Overview of progress at the time of the creation of this PR (in chronological order):</summary>
<br>
✅ <code>ui-checkin</code>
<br>
✅ <code>ui-checkout</code>
<br>
☑️ <code>ui-circulation</code>
<br>
☑️ <code>ui-calendar</code>
<br>
✅ <code>ui-agreements</code>
<br>
☑️ <code>ui-app-template</code>
<br>
☑️ <code>ui-inventory</code>
<br>
☑️ <code>ui-data-export</code>
<br>
✅ <code>ui-finc-config</code>
<br>
☑️ <code>ui-licenses</code>
<br>
☑️ <code>ui-erm-comparisons</code>
<br>
☑️ <code>ui-myprofile</code>
<br>
☑️ <code>ui-local-kb-admin</code>
<br>
☑️ <code>ui-marccat</code>
<br>
☑️ <code>ui-finc-select</code>
<br>
☑️ <code>ui-erm-usage</code>
<br>
☑️ <code>ui-notes</code>
<br>
☑️ <code>ui-oai-pmh</code>
<br>
☑️ <code>ui-plugin-find-user</code>
<br>
☑️ <code>ui-plugin-find-eresource</code>
<br>
☑️ <code>ui-plugin-find-package-title</code>
</details>

## Approach
- [x] Cloned, installed, and then ran tests to double check that the tests are passing before refactoring.
- [x] Removed `@bigtest/mirage` and added `inflected` and `miragejs`.
- [x] ESlint & ran tests after the refactor to confirm they all pass.
- [x] Updated CHANGELOG.