### PR TITLE
UIPFPAT-14 Fix Titles: Search by Tag does not display results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.0] (IN PROGRESS)
+
+* Fix Titles: Search by Tag does not display results. Refs UIPFPAT-14.
+
 ## [3.0.0] (https://github.com/folio-org/ui-plugin-find-package-title/tree/v3.0.0) (2021-03-10)
 
 * Fixed Title search is returning inaccurate results. Refs UIPFPAT-12.

--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -201,7 +201,7 @@ const SearchForm = ({
           disabled={resetButtonDisabled}
           onClick={onResetAll}
         />
-        {searchType === searchTypes.PACKAGE && tagsExist && renderTagsFilter()}
+        {tagsExist && renderTagsFilter()}
         {searchType === searchTypes.PACKAGE && accessTypesExist && renderAccessTypesFilter()}
         <SearchFilters
           activeFilters={searchFilters}

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import {
   isEqual,
   omit,
+  uniqBy,
 } from 'lodash';
 import queryString from 'qs';
 
@@ -195,7 +196,7 @@ const SearchModal = ({
 
     const { records } = resourcesToBeDisplayed;
 
-    const jointRecords = records.reduce((acc, rec) => [...acc, ...rec.data], []);
+    const jointRecords = uniqBy(records.reduce((acc, rec) => [...acc, ...rec.data], []), 'id');
 
     if (isPackageSearch) {
       return getFormattedPackagesData(jointRecords);


### PR DESCRIPTION
## Description
Fix Titles: Search by Tag does not display results

## TODOs and open questions
There's an issue with API - it returns duplicate titles with same resources when a title is included in two packages. To fix this in UI I added `uniqBy` filtering by id, but we should check if this is something that can be fixed on back-end.

## Issues
[UIPFPAT-14](https://issues.folio.org/browse/UIPFPAT-14)