### PR TITLE
UIPFPAT-47: eholdings Plug-in | Title Search | Click Previous and Next does not shift focus to the first result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [4.2.0] (https://github.com/folio-org/ui-plugin-find-package-title/tree/v4.2.0) (2022-10-24)
 
 * Translations updates
+* eholdings Plug-in | Title Search | Click Previous and Next does not shift focus to the first result. Refs UIPFPAT-47.
 
 ## [4.1.0] (https://github.com/folio-org/ui-plugin-find-package-title/tree/v4.1.0) (2022-06-20)
 

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -102,7 +102,8 @@ const propTypes = {
   }).isRequired,
 };
 
-const PAGE_SIZE = 25;
+const PACKAGE_PAGE_SIZE = 25;
+const TITLES_PAGE_SIZE = 100000; // to hide focus after clicking Next or Previous button
 
 const SearchModal = ({
   open,
@@ -223,8 +224,9 @@ const SearchModal = ({
     return records[records.length - 1].meta.totalResults;
   };
 
+  const pageSize = isPackageSearch ? PACKAGE_PAGE_SIZE : TITLES_PAGE_SIZE;
   const formattedResults = getFormattedListItems();
-  const paginatedResults = new Array(currentSearchConfig.currentPage * PAGE_SIZE);
+  const paginatedResults = new Array(currentSearchConfig.currentPage * pageSize);
   paginatedResults.push(...formattedResults);
   const totalResults = getTotalResults();
 

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -160,7 +160,7 @@ const SearchModal = ({
   const resourcesToBeDisplayed = resources?.[okapiResource];
 
   const hasLoaded = !!resourcesToBeDisplayed?.hasLoaded;
-  const fetchIsPending = !hasLoaded && resourcesToBeDisplayed?.isPending;
+  const fetchIsPending = resourcesToBeDisplayed?.isPending;
 
   const tagsLoaded = !!resources.tags?.hasLoaded;
   const tagsExist = tagsLoaded && !!resources.tags?.records[0]?.tags?.length;
@@ -175,18 +175,6 @@ const SearchModal = ({
   const formattedAccessTypes = accessTypesExist
     ? resources.accessTypes?.records[0]?.data.map(({ attributes }) => ({ value: attributes.name, label: attributes.name }))
     : [];
-
-  const getFocusIndex = () => {
-    if (currentSearchConfig.currentPage) {
-      return (currentSearchConfig.currentPage * PAGE_SIZE).toString();
-    }
-
-    if (currentSearchConfig.offset) {
-      return currentSearchConfig.currentPage.toString();
-    }
-
-    return null;
-  };
 
   const getMappingData = ({ attributes, id, type }) => ({
     ...attributes,
@@ -511,6 +499,26 @@ const SearchModal = ({
     return '';
   };
 
+  const getFocusIndex = () => {
+    if (currentSearchConfig.currentPage) {
+      return (currentSearchConfig.currentPage * PAGE_SIZE).toString();
+    }
+
+    if (currentSearchConfig.offset) {
+      return currentSearchConfig.currentPage.toString();
+    }
+
+    return null;
+  };
+
+  const focusFirstListItem = (listContainer) => {
+    const focusIndex = getFocusIndex();
+
+    if (focusIndex) {
+      listContainer.querySelector(`[data-row-inner="${focusIndex}"]`)?.focus();
+    }
+  };
+
   const renderModalFooter = () => {
     if (!isMultiSelect) {
       return null;
@@ -606,7 +614,11 @@ const SearchModal = ({
                 hasLoaded={hasLoaded}
                 isMultiSelect={isMultiSelect}
                 searchType={searchType}
-                focusIndex={isTitleSearch ? getFocusIndex() : null}
+                containerRef={ref => {
+                  if (ref && isTitleSearch) {
+                    focusFirstListItem(ref);
+                  }
+                }}
               />
             )
             : (

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -102,8 +102,7 @@ const propTypes = {
   }).isRequired,
 };
 
-const PACKAGE_PAGE_SIZE = 25;
-const TITLES_PAGE_SIZE = 100000; // to hide focus after clicking Next or Previous button
+const PAGE_SIZE = 25;
 
 const SearchModal = ({
   open,
@@ -129,6 +128,7 @@ const SearchModal = ({
       searchFilters: getInitialFiltersState(currentSearchType),
       searchByTagsEnabled: false,
       searchAccessTypesEnabled: false,
+      offset: '',
     };
 
     if (currentSearchType === searchTypes.TITLE) {
@@ -142,6 +142,7 @@ const SearchModal = ({
   const [packageSearchConfig, setPackageSearchConfig] = useState(() => getInitialSearchConfig(searchTypes.PACKAGE));
   const [titlesSearchConfig, setTitleSearchConfig] = useState(() => getInitialSearchConfig(searchTypes.TITLE));
   const isPackageSearch = searchType === searchTypes.PACKAGE;
+  const isTitleSearch = searchType === searchTypes.TITLE;
   const okapiResource = isPackageSearch ? 'packages' : 'titles';
 
   const changeCurrentSearchConfig = updater => {
@@ -174,6 +175,18 @@ const SearchModal = ({
   const formattedAccessTypes = accessTypesExist
     ? resources.accessTypes?.records[0]?.data.map(({ attributes }) => ({ value: attributes.name, label: attributes.name }))
     : [];
+
+  const getFocusIndex = () => {
+    if (currentSearchConfig.currentPage) {
+      return (currentSearchConfig.currentPage * PAGE_SIZE).toString();
+    }
+
+    if (currentSearchConfig.offset) {
+      return currentSearchConfig.currentPage.toString();
+    }
+
+    return null;
+  };
 
   const getMappingData = ({ attributes, id, type }) => ({
     ...attributes,
@@ -224,9 +237,8 @@ const SearchModal = ({
     return records[records.length - 1].meta.totalResults;
   };
 
-  const pageSize = isPackageSearch ? PACKAGE_PAGE_SIZE : TITLES_PAGE_SIZE;
   const formattedResults = getFormattedListItems();
-  const paginatedResults = new Array(currentSearchConfig.currentPage * pageSize);
+  const paginatedResults = new Array(currentSearchConfig.currentPage * PAGE_SIZE);
   paginatedResults.push(...formattedResults);
   const totalResults = getTotalResults();
 
@@ -328,6 +340,7 @@ const SearchModal = ({
       ...prev,
       lastFetchedPage: pageToFetch,
       currentPage: offset === 'next' ? prev.currentPage + 1 : prev.currentPage - 1,
+      offset,
     }));
   };
 
@@ -419,6 +432,7 @@ const SearchModal = ({
       searchByTagsEnabled: false,
       searchAccessTypesEnabled: false,
       searchFilters: getInitialFiltersState(searchType),
+      offset: '',
     }));
   };
 
@@ -592,6 +606,7 @@ const SearchModal = ({
                 hasLoaded={hasLoaded}
                 isMultiSelect={isMultiSelect}
                 searchType={searchType}
+                focusIndex={isTitleSearch ? getFocusIndex() : null}
               />
             )
             : (

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -19,7 +19,7 @@ import {
 } from '../../constants';
 
 const propTypes = {
-  focusIndex: PropTypes.string,
+  containerRef: PropTypes.func,
   isMultiSelect: PropTypes.bool,
   items: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.shape({
@@ -43,7 +43,7 @@ const SearchResultsList = ({
   hasLoaded,
   isMultiSelect,
   searchType,
-  focusIndex,
+  containerRef,
 }) => {
   const intl = useIntl();
   const [, setItemsAreLoaded] = useState(false);
@@ -141,7 +141,6 @@ const SearchResultsList = ({
         )
       }}
       contentData={items}
-      focusIndex={focusIndex}
       isEmptyMessage={emptyMessage}
       totalCount={totalCount}
       onNeedMoreData={onNeedMoreData}
@@ -150,6 +149,7 @@ const SearchResultsList = ({
       onRowClick={(_e, item) => { onRecordChosen(item); }}
       autosize
       pageAmount={25}
+      containerRef={containerRef}
     />
   );
 };

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -19,6 +19,7 @@ import {
 } from '../../constants';
 
 const propTypes = {
+  focusIndex: PropTypes.string,
   isMultiSelect: PropTypes.bool,
   items: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.shape({
@@ -42,6 +43,7 @@ const SearchResultsList = ({
   hasLoaded,
   isMultiSelect,
   searchType,
+  focusIndex,
 }) => {
   const intl = useIntl();
   const [, setItemsAreLoaded] = useState(false);
@@ -139,6 +141,7 @@ const SearchResultsList = ({
         )
       }}
       contentData={items}
+      focusIndex={focusIndex}
       isEmptyMessage={emptyMessage}
       totalCount={totalCount}
       onNeedMoreData={onNeedMoreData}


### PR DESCRIPTION
## Purpose
Add focus to the first item of the list after clicking on the `Next` or `Previous` button.
## Issues
[UIPFPAT-47](https://issues.folio.org/browse/UIPFPAT-47)

## Screencast







https://user-images.githubusercontent.com/77053927/208912131-48c54d28-340b-44eb-bdb6-5dc7d9b4091b.mp4





