### PR TITLE
UIPFPAT-56 Update Node.js to v18 in GitHub Actions

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -27,7 +27,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folio/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folio/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       OKAPI_PULL: '{ "urls" : [ "https://folio-registry.dev.folio.org" ] }'

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -24,7 +24,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folioci/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       SQ_LCOV_REPORT: 'artifacts/coverage-jest/lcov.info'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## [6.0.0] (IN PROGRESS)
+
+* Update Node.js to v18 in GitHub Actions. Refs UIPFPAT-56.
+
 ## [5.0.0] (https://github.com/folio-org/ui-plugin-find-package-title/tree/v5.0.0) (2023-02-20)
 
 * bump stripes to 8.0.0 for Orchid/2023-R1. Refs UIPFPAT-52.

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=14.0.0"
-  },
   "stripes": {
     "actsAs": [
       "plugin"


### PR DESCRIPTION
## Description
Update Node.js to v18 in GitHub Actions

## Issues
[UIPFPAT-56](https://issues.folio.org/browse/UIPFPAT-56)