### PR TITLE
UIPFPAT-57 Remove eslint deps that are already listed in eslint-config-stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Change history for ui-plugin-find-package-title
+
+## [6.1.0] (IN PROGRESS)
+
+* Remove eslint deps that are already listed in eslint-config-stripes. Refs UIPFPAT-57.
 
 ## [6.0.0] (https://github.com/folio-org/ui-plugin-find-package-title/tree/v6.0.0) (2023-10-12)
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "eholdings": "2.0"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.17.0",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/jest-config-stripes": "^2.0.0",
     "@folio/stripes": "^9.0.0",
@@ -40,7 +39,6 @@
     "@folio/stripes-testing": "^4.5.0",
     "@formatjs/cli": "^6.1.3",
     "core-js": "^3.6.4",
-    "eslint": "^7.32.0",
     "eslint-plugin-jest": "^24.1.3",
     "identity-obj-proxy": "^3.0.0",
     "inflected": "^2.0.4",


### PR DESCRIPTION
## Description
Remove eslint deps that are already listed in eslint-config-stripes

## Issues
[UIPFPAT-57](https://issues.folio.org/browse/UIPFPAT-57)